### PR TITLE
Se convierte el repo en un único módulo

### DIFF
--- a/00-hola/go.mod
+++ b/00-hola/go.mod
@@ -1,3 +1,0 @@
-module github.com/untref-ayp2/taller-GO/00-hola
-
-go 1.22

--- a/01-tipodatos/go.mod
+++ b/01-tipodatos/go.mod
@@ -1,3 +1,0 @@
-module github.com/untref-ayp2/taller-GO/01-tipodatos
-
-go 1.22

--- a/02-variables/go.mod
+++ b/02-variables/go.mod
@@ -1,3 +1,0 @@
-module github.com/untref-ayp2/taller-GO/02-variables
-
-go 1.22

--- a/03-constantes/go.mod
+++ b/03-constantes/go.mod
@@ -1,3 +1,0 @@
-module github.com/untref-ayp2/taller-GO/03-constantes
-
-go 1.22

--- a/04-funciones/go.mod
+++ b/04-funciones/go.mod
@@ -1,3 +1,0 @@
-module github.com/untref-ayp2/taller-GO/04-funciones
-
-go 1.22

--- a/05-condicionales/go.mod
+++ b/05-condicionales/go.mod
@@ -1,3 +1,0 @@
-module github.com/untref-ayp2/taller-GO/05-condicionales
-
-go 1.22

--- a/06-ciclos/go.mod
+++ b/06-ciclos/go.mod
@@ -1,3 +1,0 @@
-module github.com/untref-ayp2/taller-GO/06-ciclos
-
-go 1.22

--- a/07-punteros/go.mod
+++ b/07-punteros/go.mod
@@ -1,3 +1,0 @@
-module github.com/untref-ayp2/taller-GO/07-punteros
-
-go 1.22

--- a/08-arreglos/go.mod
+++ b/08-arreglos/go.mod
@@ -1,3 +1,0 @@
-module github.com/untref-ayp2/taller-GO/08-arreglos
-
-go 1.22

--- a/09-mapas/go.mod
+++ b/09-mapas/go.mod
@@ -1,3 +1,0 @@
-module github.com/untref-ayp2/taller-GO/09-mapas
-
-go 1.22

--- a/10-figuras/go.mod
+++ b/10-figuras/go.mod
@@ -1,3 +1,0 @@
-module github.com/untref-ayp2/taller-GO/10-figuras
-
-go 1.22

--- a/11-errores/go.mod
+++ b/11-errores/go.mod
@@ -1,3 +1,0 @@
-module github.com/untref-ayp2/taller-GO/11-errores
-
-go 1.22

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module github.com/untref-ayp2/taller-GO
+
+go 1.22


### PR DESCRIPTION
De esta forma es más simple para ejecutar los ejemplos, lo cual podemos hacerlo de todas estas formas:

```bash
~/ayp2/taller-GO ❯ go run ./00-hola/main.go 
¡Hola, Mundo!

~/ayp2/taller-GO ❯ go run ./00-hola        
¡Hola, Mundo!

~/ayp2/taller-GO ❯ go run ./00-hola/.
¡Hola, Mundo!

~/ayp2/taller-GO ❯ go run github.com/untref-ayp2/taller-GO/00-hola
¡Hola, Mundo!

~/ayp2/taller-GO ❯ cd 00-hola 

~/ayp2/taller-GO/00-hola ❯ go run .
¡Hola, Mundo!

~/ayp2/taller-GO/00-hola ❯ go run main.go 
¡Hola, Mundo!

~/ayp2/taller-GO/00-hola ❯ go run github.com/untref-ayp2/taller-GO/00-hola 
¡Hola, Mundo!

~/ayp2/taller-GO/00-hola ❯ cd ../07-punteros # desde cualquier lado dentro del módulo

~/ayp2/taller-GO/07-punteros ❯ go run github.com/untref-ayp2/taller-GO/00-hola 
¡Hola, Mundo!

```